### PR TITLE
Update documentation and issue tracker URLs in manifest

### DIFF
--- a/custom_components/lsc_tuya_doorbell/manifest.json
+++ b/custom_components/lsc_tuya_doorbell/manifest.json
@@ -4,10 +4,10 @@
   "codeowners": ["@jurgenmahn"],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/jurgenmahn/ha-lsc-tuya-v2",
+  "documentation": "https://github.com/jurgenmahn/ha_tuya_doorbell",
   "icon": "mdi:doorbell-video",
   "iot_class": "local_push",
-  "issue_tracker": "https://github.com/jurgenmahn/ha-lsc-tuya-v2/issues",
+  "issue_tracker": "https://github.com/jurgenmahn/ha_tuya_doorbell/issues",
   "requirements": ["cryptography>=41.0.0"],
   "version": "2.8.0",
   "homeassistant": "2024.1.0"


### PR DESCRIPTION
The linked repo doesnt exist or is not public. I'm assuming the repo has been renamed and it just didnt get updated