### PR TITLE
docs/add-lsc-doorbell-event-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,12 @@ custom_components/lsc_tuya_doorbell/
 
 The protocol implementation is independent of Home Assistant and can be used standalone (see the `tools/` directory).
 
+## Related projects
+
+- [LSC Doorbell Event Bridge](https://github.com/GiannBart/lsc-doorbell-event-bridge) — A Home Assistant App primarily intended for selected battery-powered LSC/Tuya video doorbells. It receives events through the Tuya Message Service and exposes motion detection, doorbell presses, snapshots, power mode, and battery level through MQTT.
+
+LSC Doorbell Event Bridge uses a cloud-event-based approach and may be useful for battery-powered devices that cannot maintain a stable local connection. For compatible wired or locally accessible devices, the local integration provided by this repository remains the recommended approach.
+
 ## Credits
 
 Built by [Jurgen Mahn](https://github.com/jurgenmahn) with [Claude Code](https://claude.ai/code).


### PR DESCRIPTION
Hi Jürgen,

first of all, thank you for your work on **ha_tuya_doorbell**.

My project, [LSC Doorbell Event Bridge](https://github.com/GiannBart/lsc-doorbell-event-bridge), originally started while I was trying to use and adapt your integration for my battery-powered LSC/Tuya video doorbell.

Over time, it evolved into a completely independent project with a substantially different architecture. Instead of communicating directly with the device over the local network, it receives events through the Tuya Message Service and exposes them to Home Assistant through MQTT.

Although the two projects now follow different approaches, your work was an important starting point and source of inspiration for mine.

I have already added references to your work in my repository's README. I included a link to **ha_tuya_doorbell**, credited your project as an important source of inspiration, and recommended it to users looking for a local solution, especially for wired devices or devices that can maintain a stable local network connection.

With this pull request, I would also like to add a brief reference to **LSC Doorbell Event Bridge** among the related projects, so users can discover both solutions and choose the one that best suits their device and setup.

I also wanted to make sure that you are comfortable with the references to your work that I have already included in my README. If you would rather not be mentioned or linked from my project page, please let me know and I will promptly remove those references.

Please feel free to suggest any changes to the wording or to decline this pull request.

Thank you again for sharing your work with the Home Assistant community.
